### PR TITLE
Fix or remove three bad URLs in datafeed.txt

### DIFF
--- a/datafeed.txt
+++ b/datafeed.txt
@@ -405,7 +405,7 @@ data {
   nid: 3245
   election_id: 2000
   title: "CA 2012 General"
-  feed_url: "https://data.votinginfoproject.org/feeds/ca/vipFeed-6065-2012-11-06.zip"
+  feed_url: "https://data.votinginfoproject.org/feeds/ca/vipFeed-06065-2012-11-06.zip"
   is_test_election: true
   user: "noma@turbovote.org"
 }

--- a/datafeed.txt
+++ b/datafeed.txt
@@ -1113,15 +1113,6 @@ data {
   user: "noma@democracy.works"
 }
 
-## NC Primary Election
-data {
-  nid: 4033
-  election_id: 4137
-  title: "NC Primary Election"
-  feed_url: "https://data.votinginfoproject.org/feeds/nc/vipfeed-37-2015-09-15.zip"
-  user: "noma@democracy.works"
-}
-
 ## TX Test Election
 data {
   nid: 4034

--- a/datafeed.txt
+++ b/datafeed.txt
@@ -15,7 +15,7 @@ data {
   nid: 3205
   election_id: 2000
   title: "NV 2014 Primary"
-  feed_url: "https://data.votinginfoproject.org/feeds/nv/vipFeed-32-2014-06-10.zip"
+  feed_url: "https://data.votinginfoproject.org/feeds/nv/VIPFeed-32-2014-06-10.zip"
   is_test_election: true
   user: "noma@turbovote.org"
 }


### PR DESCRIPTION
Hi VIP folks,

I'm experimenting with a change to the way we fetch VIP feeds that should end up giving a significant speedup to pipeline processing. Unfortunately, the new fetcher complains loudly (to me) if any URLs can't actually be fetched, so to protect my inbox I've fixed a couple bad URLs (and removed one no-longer-available dataset from the list) that we've been silently ignoring for months.

Thanks,
Jonathan